### PR TITLE
Add BasicAuth configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ return array(
     'sylvainjule.matomo.trackUsers'     => false,
     'sylvainjule.matomo.disableCookies' => false,
     'sylvainjule.matomo.blacklist'      => ['127.0.0.1', '::1'],
+    'sylvainjule.matomo.basicAuth'      => null,
+
 );
 ```
 
@@ -144,6 +146,14 @@ If you want to use Matomo without any tracking cookies on the user side, set thi
 
 ```php
 'sylvainjule.matomo.disableCookies' => false
+```
+
+#### 3.9. `basicAuth`
+
+If your Matomo instance is additionally secured by Basic Authentication, you can configure these credentials in the format `USERNAME:PASSWORD`.
+
+```php
+'sylvainjule.matomo.basicAuth' => null
 ```
 
 <br/>

--- a/lib/matomo.php
+++ b/lib/matomo.php
@@ -35,6 +35,7 @@ class Matomo {
 	protected $url   = null;
 	protected $id    = null;
 	protected $token = null;
+	protected $requestParams = [];
 	protected $methodsMap = array (
 		'referrerType' => 'Referrers.getReferrerType',
 		'websites'     => 'Referrers.getWebsites',
@@ -48,6 +49,9 @@ class Matomo {
     	$this->url   = option('sylvainjule.matomo.url');
 		$this->id    = option('sylvainjule.matomo.id');
 		$this->token = is_callable($this->token) ? $this->token() : option('sylvainjule.matomo.token');
+		if (option('sylvainjule.matomo.basicAuth') !== null) {
+			$this->requestParams['basicAuth'] = option('sylvainjule.matomo.basicAuth');
+		}
     }
 
 	public function apiWidget($widget, $method, $period, $date, $limit, $lang) {
@@ -58,7 +62,7 @@ class Matomo {
 		$url .= $limit ? "&filter_limit=" . $limit : '';
 		$url .= "&token_auth=". $this->token;
 
-        $content = Remote::get($url)->json();
+        $content = Remote::get($url, $this->requestParams)->json();
         return $content;
 	}
 
@@ -77,7 +81,7 @@ class Matomo {
 			$i++;
 		}
 
-        $content = Remote::get($url)->content();
+        $content = Remote::get($url, $this->requestParams)->content();
         return $content;
 	}
 
@@ -87,7 +91,7 @@ class Matomo {
 		$url .= "&idSite=". $this->id ."&period=". $period ."&date=" . $date;
 		$url .= "&format=JSON&token_auth=". $this->token;
 
-        $content = Remote::get($url)->json();
+        $content = Remote::get($url, $this->requestParams)->json();
         return $content;
 	}
 
@@ -97,7 +101,7 @@ class Matomo {
 		$url .= "&idSite=". $this->id ."&period=". $period ."&date=" . $date;
 		$url .= "&format=JSON&token_auth=". $this->token;
 
-        $content = Remote::get($url)->json();
+        $content = Remote::get($url, $this->requestParams)->json();
         return $content;
 	}
 
@@ -109,7 +113,7 @@ class Matomo {
 		$url .= "&idSite=". $this->id ."&lastMinutes=3";
 		$url .= "&format=JSON&token_auth=". $this->token;
 
-        $content = Remote::get($url)->json();
+        $content = Remote::get($url, $this->requestParams)->json();
 		return $content;
 	}
 
@@ -131,7 +135,7 @@ class Matomo {
 		$url .= "&urls[3]=";
 		$url .= urlencode("method=VisitsSummary.getVisits&idSite=". $this->id ."&period=year&date=today");
 
-        $content = Remote::get($url)->json();
+        $content = Remote::get($url, $this->requestParams)->json();
         return $content;
 	}
 
@@ -142,7 +146,7 @@ class Matomo {
 		$url .= "&format=JSON&token_auth=". $this->token;
 		$url .= $lang['multilang'] ? '&expanded=1' : '';
 
-        $content = Remote::get($url)->json();
+        $content = Remote::get($url, $this->requestParams)->json();
 		$content = $this->filterPageMetrics($content, $uri, $lang);
 		return $content;
 	}


### PR DESCRIPTION
I had an unusual case where Matomo was additionally secured with basicAuth. This pull request adds the possibility to configure the basicAuth credentials.