### PR TITLE
Fix #44

### DIFF
--- a/lib/matomo.php
+++ b/lib/matomo.php
@@ -166,7 +166,7 @@ class Matomo {
 
 		// set the correct language and find the page
 		if($multilang) $site->visit($site->homePage(), $currentLang);
-		$page   = $site->childrenAndDrafts()->find($uri);
+		$page   = $site->index()->find($uri);
 
 		// re-create the uri from the public url
 		$currentUrl  = $page->url(); // get the page url

--- a/lib/matomo.php
+++ b/lib/matomo.php
@@ -144,6 +144,7 @@ class Matomo {
 		$url .= "?module=API&method=Actions.getPageUrls";
 		$url .= "&idSite=". $this->id ."&period=". $period ."&date=today";
 		$url .= "&format=JSON&token_auth=". $this->token;
+        $url .= "&flat=1";
 		$url .= $lang['multilang'] ? '&expanded=1' : '';
 
         $content = Remote::get($url, $this->requestParams)->json();


### PR DESCRIPTION
This pull request changes the `$site->childrenAndDrafts()->find($uri)` call in the `filterPageMetrics` method to `$site->index()->find($uri)` to find nested children pages. It also adds the `flat` query filter to the `GET` request scheduled in the `apiPageMetrics` method.

Therefore nested child pages (e.g. /posts/example-post-page) can display their Matomo stats in the `matomo-page` section.